### PR TITLE
Add PhantomData field to Context struct.

### DIFF
--- a/examples/mercpcl.rs
+++ b/examples/mercpcl.rs
@@ -26,8 +26,8 @@ mod mercury {
     use bitreader::BitReader;
     use ftdi::mpsse::MpsseMode;
 
-    pub struct Mercury {
-        context : ftdi::Context,
+    pub struct Mercury<'a> {
+        context : ftdi::Context<'a>,
     }
 
     #[derive(Debug)]
@@ -95,8 +95,8 @@ mod mercury {
     }
 
 
-    impl Mercury {
-        pub fn new() -> Mercury {
+    impl<'a> Mercury<'a> {
+        pub fn new() -> Mercury<'a> {
             Mercury {
                 context : ftdi::Context::new().unwrap()
             }


### PR DESCRIPTION
Should cause context lifetime to be handled correctly. Also removes the
need for many of the explicit lifetimes.

I'm not 100% sure this is right but I think it is - see https://doc.rust-lang.org/nomicon/phantom-data.html for why.