### PR TITLE
Fix Mercury example and remove need for NLL

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Z", "polonius"]

--- a/examples/mercpcl.rs
+++ b/examples/mercpcl.rs
@@ -26,8 +26,8 @@ mod mercury {
     use bitreader::BitReader;
     use ftdi::mpsse::MpsseMode;
 
-    pub struct Mercury {
-        context : ftdi::Context,
+    pub struct Mercury<'a> {
+        context : ftdi::Context<'a>,
     }
 
     #[derive(Debug)]
@@ -95,8 +95,8 @@ mod mercury {
     }
 
 
-    impl Mercury {
-        pub fn new() -> Mercury {
+    impl<'a> Mercury<'a> {
+        pub fn new() -> Mercury<'a> {
             Mercury {
                 context : ftdi::Context::new().unwrap()
             }


### PR DESCRIPTION
This PR (which is on top of the `PhantomData` PR, although it needn't be) fixes the Mercury example while preserving soundness (`ftdi::error::Error` has a lifetime which is shorter than or equal to the lifetime of `ftdi::lib::Context`). It also removes the need for NLL (which, after the first bit, just required swapping around some scopes with argparse).

The reason this works is that it communicates to the compiler that while the lifetimes of `ftdi::error::Error` and `ftdi::lib::Context` are _related_, they're not the _same_, and so it's allowed to shorten the Error lifetime and we don't get all these issues with multiple borrows on Context.

This works but honestly it'd be a lot easier to just use an owned `String`... if you decide you want to go that way, I'd be happy to implement it.