### PR TITLE
Make everything in Context public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,13 @@ use error::*;
 
 
 pub struct Context {
-    context : *mut ftdic::ftdi_context,
+    pub context : *mut ftdic::ftdi_context,
 }
 
 pub type Result<T> = result::Result<T, error::Error>;
 
 impl Context {
-    fn check_ftdi_error<T>(&self, rc : raw::c_int, ok_val : T) -> Result<T> {
+    pub fn check_ftdi_error<T>(&self, rc : raw::c_int, ok_val : T) -> Result<T> {
         if rc < 0 {
             // From looking at libftdi library, the error string is always a static
             // string literal.


### PR DESCRIPTION
Hi, and thank you for this extremely useful library. As a novice Rust user this was extremely educational and easy to understand from its source; I really appreciated it.

Apologies for the spam of multiple PRs I'm sending, but hopefully each is a trivial decision on its own and hopefully they're maybe somewhat helpful.

Here I'm proposing making the wrapped libftdi `context` and the `check_ftdi_error` helper function public. When I was writing a program based on this library, but needing an extra function that was not in safe-ftdi yet, the fact that these things were private forced me to immediately import the whole safe-ftdi source and modify it, rather than just quickly adding the one function I needed in an extra trait.

With these things made public, it's much easier to fill in missing functionality as needed (probably-bad example [here](https://github.com/tsprlng/dmx-control/blob/c771580d7aebc2af458544827febdddebcbc2604/src/main.rs#L11)). I believe this should save future users time in similar situations, without having to extend this library to support the entirety of libftdi's header right away.