### PR TITLE
Preserve specific error messages from libftdi

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,9 +25,9 @@ impl LibFtdiError {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::LibFtdi(_) => {
-                write!(f, "libftdi-internal error")
+        match &*self {
+            Error::LibFtdi(e) => {
+                e.fmt(f)
             },
             Error::MallocFailure => {
                 write!(f, "malloc() failure")


### PR DESCRIPTION
I'm not totally sure if I'm doing this in an idiomatic way, but in my opinion it's definitely useful to get the specific text from each error by default.