### PR TITLE
Fix bare_trait_objects warning (default on since 1.37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ transitively `safe-ftdi` requires it as well. I have tested the bindings
 on Windows using the [MSYS2](https://www.msys2.org) environment, and
 the GNU ABI version of `rustc`.
 
-The library in principle compiles on stable Rust 1.26 or greater,
-which is when the `?` operator was introduced. Older nightly compilers
+The library in principle compiles on stable Rust 1.27 or greater,
+which is when the `dyn` syntax was introduced. Older nightly compilers
 should be able to compile `safe-ftdi` as well.
 
 ## License

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ impl fmt::Display for LibFtdiError {
 }
 
 impl std::error::Error for Error {
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::LibFtdi(ref ftdi_err) => {
                 Some(ftdi_err)


### PR DESCRIPTION
This change to use the `dyn` syntax for trait objects (added in 1.27) is now needed to silence a warning that is on by default since 1.37. However, I'm not sure if there is perhaps a specific reason to stay compatible with 1.26.