### PR TITLE
Major update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-ftdi"
-version = "0.2.1"
+version = "1.0.0"
 license = "MIT/Apache-2.0"
 description = "A safe wrapper around libftdi."
 repository = "https://github.com/cr1901/safe-ftdi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["api-bindings", "embedded"]
 readme = "README.md"
 
 [dependencies]
-libftdi1-sys = "1.0.0-alpha3"
+libftdi1-sys = { git = "https://github.com/eloc3147/libftdi1-sys", features = ["libusb1-sys"] }
 
 [dev-dependencies]
 argparse = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["api-bindings", "embedded"]
 readme = "README.md"
 
 [dependencies]
-libftdi1-sys = { git = "https://github.com/eloc3147/libftdi1-sys" }
+libftdi1-sys = "1.0.0"
 
 [dev-dependencies]
 argparse = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-ftdi"
-version = "1.0.0"
+version = "0.3.0"
 license = "MIT/Apache-2.0"
 description = "A safe wrapper around libftdi."
 repository = "https://github.com/cr1901/safe-ftdi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["api-bindings", "embedded"]
 readme = "README.md"
 
 [dependencies]
-libftdi1-sys = "0.1.0"
+libftdi1-sys = "1.0.0-alpha3"
 
 [dev-dependencies]
 argparse = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["api-bindings", "embedded"]
 readme = "README.md"
 
 [dependencies]
-libftdi1-sys = { git = "https://github.com/eloc3147/libftdi1-sys", features = ["libusb1-sys"] }
+libftdi1-sys = { git = "https://github.com/eloc3147/libftdi1-sys" }
 
 [dev-dependencies]
 argparse = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [dependencies]
 libftdi1-sys = "1.0.0"
 
+[features]
+vendored = ["libftdi1-sys/vendored"]
+
 [dev-dependencies]
 argparse = "0.2.2"
 bitreader = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 libftdi1-sys = "1.0.0"
 
 [features]
+default = []
 vendored = ["libftdi1-sys/vendored"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 as a thin wrapper around
 [`libftdi1-sys`](https://github.com/tanriol/libftdi1-sys). Functions from
 `libftdi` are implemented in `safe-ftdi` on an as-needed basis, and they
-arr named the same as their `libftdi` counterparts with the `ftdi_` prefix
-stripped.
+are mostly named the same as their `libftdi` counterparts with the `ftdi_`
+prefix stripped.
 
 Documentation on specific functions will come soon, but the example
 directory contains a reimplementation of
@@ -20,14 +20,12 @@ FPGA development board using the bitbang mode of the FT245.
 ## Prerequisites
 
 [`libftdi1-sys`](https://github.com/tanriol/libftdi1-sys) requires the
-[`pkg-config`](https://crates.io/crates/pkg-config) crate, and so
-transitively `safe-ftdi` requires it as well. I have tested the bindings
-on Windows using the [MSYS2](https://www.msys2.org) environment, and
-the GNU ABI version of `rustc`.
+[`pkg-config`](https://crates.io/crates/pkg-config) crate everywhere except on Windows/MSVC, where it requires [`vcpkg`](https://crates.io/crates/vcpkg), and so
+transitively `safe-ftdi` requires one of those as well. I have tested the bindings
+on the Windows MSVC environment, and the GNU ABI version of `rustc`.
 
-The library in principle compiles on stable Rust 1.27 or greater,
-which is when the `dyn` syntax was introduced. Older nightly compilers
-should be able to compile `safe-ftdi` as well.
+The library in principle compiles on stable Rust 1.34 or greater,
+which is what is required by `libftdi1-sys`.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,20 +349,23 @@ impl Device {
         self.context.check_ftdi_error(rc)
     }
 
+    /// Clears the RX and TX FIFOs on the chip and the internal read buffer.
     pub fn purge_usb_buffers(&self) -> Result<()> {
-        let rc = unsafe { ftdic::ftdi_usb_purge_buffers(self.context.get_ftdi_context()) };
+        let rc = unsafe { ftdic::ftdi_tcioflush(self.context.get_ftdi_context()) };
 
         self.context.check_ftdi_error(rc)
     }
 
+    /// Clears the read buffer on the chip and the internal read buffer.
     pub fn purge_usb_rx_buffer(&self) -> Result<()> {
-        let rc = unsafe { ftdic::ftdi_usb_purge_rx_buffer(self.context.get_ftdi_context()) };
+        let rc = unsafe { ftdic::ftdi_tciflush(self.context.get_ftdi_context()) };
 
         self.context.check_ftdi_error(rc)
     }
 
+    /// Clears the write buffer on the chip.
     pub fn purge_usb_tx_buffer(&self) -> Result<()> {
-        let rc = unsafe { ftdic::ftdi_usb_purge_tx_buffer(self.context.get_ftdi_context()) };
+        let rc = unsafe { ftdic::ftdi_tcoflush(self.context.get_ftdi_context()) };
 
         self.context.check_ftdi_error(rc)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,10 +208,10 @@ impl Device {
     ///
     /// Intended to be used for parsing a device-description given as commandline argument
     ///
-    /// - d:<devicenode> path of bus and device-node (e.g. "003/001") within usb device tree (usually at /proc/bus/usb/)
-    /// - i:<vendor>:<product> first device with given vendor and product id, ids can be decimal, octal (preceded by "0") or hex (preceded by "0x")
-    /// - i:<vendor>:<product>:<index> as above with index being the number of the device (starting with 0) if there are more than one
-    /// - s:<vendor>:<product>:<serial> first device with given vendor id, product id and serial string
+    /// - `d:<devicenode>` path of bus and device-node (e.g. "003/001") within usb device tree (usually at /proc/bus/usb/)
+    /// - `i:<vendor>:<product>` first device with given vendor and product id, ids can be decimal, octal (preceded by "0") or hex (preceded by "0x")
+    /// - `i:<vendor>:<product>:<index>` as above with index being the number of the device (starting with 0) if there are more than one
+    /// - `s:<vendor>:<product>:<serial>` first device with given vendor id, product id and serial string
     pub fn from_description_string(interface: Interface, description: String) -> Result<Device> {
         let context = Context::new()?;
         context.set_interface(interface)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,101 +1,110 @@
 extern crate libftdi1_sys as ftdic;
 use std::os::raw;
 use std::ffi::CStr;
-use std::result;
 
 pub mod mpsse;
 use mpsse::{MpsseMode};
 
 pub mod error;
-use error::*;
+use error::{Error, LibFtdiError};
 
+/// Low-level wrapper around a ftdi_context instance
+pub struct Context (*mut ftdic::ftdi_context);
 
-pub struct Context {
-    context : *mut ftdic::ftdi_context,
-}
-
-pub type Result<T> = result::Result<T, error::Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 impl Context {
-    fn check_ftdi_error<T>(&self, rc : raw::c_int, ok_val : T) -> Result<T> {
-        if rc < 0 {
-            // From looking at libftdi library, the error string is always a static
-            // string literal.
-            let slice = unsafe {
-                let err_raw = ftdic::ftdi_get_error_string(self.context);
-                CStr::from_ptr(err_raw)
-            };
-
-            // If UTF8 validation fails, no point in continuing.
-            Err(Error::LibFtdi(error::LibFtdiError::new(slice.to_str().unwrap())))
-        } else {
-            Ok(ok_val)
-        }
-    }
-
     pub fn new() -> Result<Context> {
         let ctx = unsafe { ftdic::ftdi_new() };
 
         if ctx.is_null() {
             Err(Error::MallocFailure)
         } else {
-            Ok(Context {
-                context : ctx
-            })
+            Ok(Context(ctx))
         }
     }
 
-    // Combine with new()?
-    pub fn open(&mut self, vid : u16, pid : u16) -> Result<()> {
-        let rc = unsafe {
-            ftdic::ftdi_usb_open(self.context, raw::c_int::from(vid), raw::c_int::from(pid))
-        };
+    pub fn check_ftdi_error(&self, rc : raw::c_int) -> Result<()> {
+        if rc < 0 {
+            // From looking at libftdi library, the error string is always a static
+            // string literal.
+            let slice = unsafe {
+                let err_raw = ftdic::ftdi_get_error_string(self.0);
+                CStr::from_ptr(err_raw)
+            };
 
-        self.check_ftdi_error(rc, ())
+            // If UTF8 validation fails, no point in continuing.
+            Err(Error::LibFtdi(LibFtdiError::new(slice.to_str().unwrap())))
+        } else {
+            Ok(())
+        }
     }
 
     pub fn get_ftdi_context(&self) -> *mut ftdic::ftdi_context {
-        self.context
+        self.0
+    }
+}
+
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        unsafe { ftdic::ftdi_free(self.0) }
+    }
+}
+
+pub struct Device {
+    context: Context
+}
+
+impl Device {
+    pub fn open(vid : u16, pid : u16) -> Result<Device> {
+        let context = Context::new()?;
+        let rc = unsafe {
+            ftdic::ftdi_usb_open(context.0, raw::c_int::from(vid), raw::c_int::from(pid))
+        };
+
+        context.check_ftdi_error(rc)?;
+        Ok(Device {context})
     }
 
     pub fn set_baudrate(&self, baudrate : u32) -> Result<()> {
         let rc = unsafe {
-            ftdic::ftdi_set_baudrate(self.context, baudrate as raw::c_int)
+            ftdic::ftdi_set_baudrate(self.context.0, baudrate as raw::c_int)
         };
 
-        self.check_ftdi_error(rc, ())
+        self.context.check_ftdi_error(rc)
     }
 
     pub fn set_bitmode(&self, bitmask : u8, mode : MpsseMode) -> Result<()> {
         let rc = unsafe {
-            ftdic::ftdi_set_bitmode(self.context, bitmask as raw::c_uchar, mode as raw::c_uchar)
+            ftdic::ftdi_set_bitmode(self.context.0, bitmask as raw::c_uchar, mode.0 as raw::c_uchar)
         };
 
-        self.check_ftdi_error(rc, ())
+        self.context.check_ftdi_error(rc)
     }
 
     pub fn purge_usb_buffers(&self) -> Result<()> {
         let rc = unsafe {
-            ftdic::ftdi_usb_purge_buffers(self.context)
+            ftdic::ftdi_usb_purge_buffers(self.context.0)
         };
 
-        self.check_ftdi_error(rc, ())
+        self.context.check_ftdi_error(rc)
     }
 
     pub fn purge_usb_rx_buffer(&self) -> Result<()> {
         let rc = unsafe {
-            ftdic::ftdi_usb_purge_rx_buffer(self.context)
+            ftdic::ftdi_usb_purge_rx_buffer(self.context.0)
         };
 
-        self.check_ftdi_error(rc, ())
+        self.context.check_ftdi_error(rc)
     }
 
     pub fn purge_usb_tx_buffer(&self) -> Result<()> {
         let rc = unsafe {
-            ftdic::ftdi_usb_purge_tx_buffer(self.context)
+            ftdic::ftdi_usb_purge_tx_buffer(self.context.0)
         };
 
-        self.check_ftdi_error(rc, ())
+        self.context.check_ftdi_error(rc)
     }
 
     pub fn read_pins(&self) -> Result<u8> {
@@ -103,10 +112,11 @@ impl Context {
         let pins_ptr = std::slice::from_mut(&mut pins).as_mut_ptr();
 
         let rc = unsafe {
-            ftdic::ftdi_read_pins(self.context, pins_ptr)
+            ftdic::ftdi_read_pins(self.context.0, pins_ptr)
         };
 
-        self.check_ftdi_error(rc, pins)
+        self.context.check_ftdi_error(rc)?;
+        Ok(pins)
     }
 
     pub fn read_data(&self, data : &mut [u8]) -> Result<u32> {
@@ -114,10 +124,11 @@ impl Context {
         let raw_len = data.len() as i32;
 
         let rc = unsafe {
-            ftdic::ftdi_read_data(self.context, raw_ptr, raw_len)
+            ftdic::ftdi_read_data(self.context.0, raw_ptr, raw_len)
         };
 
-        self.check_ftdi_error(rc, rc as u32)
+        self.context.check_ftdi_error(rc)?;
+        Ok(rc as u32)
     }
 
     pub fn write_data(&self, data : &[u8]) -> Result<u32> {
@@ -125,25 +136,10 @@ impl Context {
         let raw_len = data.len() as i32;
 
         let rc = unsafe {
-            ftdic::ftdi_write_data(self.context, raw_ptr, raw_len)
+            ftdic::ftdi_write_data(self.context.0, raw_ptr, raw_len)
         };
 
-        self.check_ftdi_error(rc, rc as u32)
-    }
-}
-
-
-impl Drop for Context {
-    fn drop(&mut self) {
-        unsafe { ftdic::ftdi_free(self.context) }
-    }
-}
-
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+        self.context.check_ftdi_error(rc)?;
+        Ok(rc as u32)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 extern crate libftdi1_sys as ftdic;
+use std::ffi::{CStr, CString};
 use std::os::raw;
-use std::ffi::CStr;
 
 pub mod mpsse;
-use mpsse::{MpsseMode};
+use mpsse::MpsseMode;
 
 pub mod error;
 use error::{Error, LibFtdiError};
 
 /// Low-level wrapper around a ftdi_context instance
-pub struct Context (*mut ftdic::ftdi_context);
+pub struct Context(*mut ftdic::ftdi_context);
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -24,7 +24,7 @@ impl Context {
         }
     }
 
-    pub fn check_ftdi_error(&self, rc : raw::c_int) -> Result<()> {
+    pub fn check_ftdi_error(&self, rc: raw::c_int) -> Result<()> {
         if rc < 0 {
             // From looking at libftdi library, the error string is always a static
             // string literal.
@@ -45,99 +45,163 @@ impl Context {
     }
 }
 
-
 impl Drop for Context {
     fn drop(&mut self) {
-        unsafe { ftdic::ftdi_free(self.0) }
+        unsafe { ftdic::ftdi_free(self.get_ftdi_context()) }
     }
 }
 
 pub struct Device {
-    context: Context
+    context: Context,
 }
 
 impl Device {
-    pub fn open(vid : u16, pid : u16) -> Result<Device> {
-        let context = Context::new()?;
-        let rc = unsafe {
-            ftdic::ftdi_usb_open(context.0, raw::c_int::from(vid), raw::c_int::from(pid))
-        };
-
-        context.check_ftdi_error(rc)?;
-        Ok(Device {context})
+    /// Opens the first device with a given vendor and product ids
+    pub fn from_vid_pid(vid: u16, pid: u16) -> Result<Device> {
+        Device::from_description_serial(vid, pid, None, None)
     }
 
-    pub fn set_baudrate(&self, baudrate : u32) -> Result<()> {
-        let rc = unsafe {
-            ftdic::ftdi_set_baudrate(self.context.0, baudrate as raw::c_int)
+    /// Opens the first device with a given, vendor id, product id, description, and serial
+    pub fn from_description_serial(
+        vid: u16,
+        pid: u16,
+        description: Option<String>,
+        serial: Option<String>,
+    ) -> Result<Device> {
+        Device::from_description_serial_index(vid, pid, description, serial, 0)
+    }
+
+    /// Opens the index-th device with a given, vendor id, product id, description, and serial
+    pub fn from_description_serial_index(
+        vid: u16,
+        pid: u16,
+        description: Option<String>,
+        serial: Option<String>,
+        index: u32,
+    ) -> Result<Device> {
+        let context = Context::new()?;
+        let (desc, desc_supplied) = match description {
+            Some(d) => (CString::new(d).unwrap().into_raw(), true),
+            None => (std::ptr::null_mut(), false),
         };
+        let (ser, ser_supplied) = match serial {
+            Some(s) => (CString::new(s).unwrap().into_raw(), true),
+            None => (std::ptr::null_mut(), false),
+        };
+
+        let rc = unsafe {
+            ftdic::ftdi_usb_open_desc_index(
+                context.0,
+                raw::c_int::from(vid),
+                raw::c_int::from(pid),
+                desc,
+                ser,
+                raw::c_uint::from(index),
+            )
+        };
+
+        if desc_supplied {
+            drop(unsafe { CString::from_raw(desc) }); // String must be manually free'd
+        }
+        if ser_supplied {
+            drop(unsafe { CString::from_raw(desc) }); // String must be manually free'd
+        }
+        context.check_ftdi_error(rc)?;
+        Ok(Device { context })
+    }
+
+    /// Opens the device at a given USB bus and device address
+    pub fn from_bus_addr(bus: u8, addr: u8) -> Result<Device> {
+        let context = Context::new()?;
+
+        let rc = unsafe { ftdic::ftdi_usb_open_bus_addr(context.get_ftdi_context(), bus, addr) };
+        context.check_ftdi_error(rc)?;
+        Ok(Device { context })
+    }
+
+    /// Opens the ftdi-device described by a description-string
+    ///
+    /// Intended to be used for parsing a device-description given as commandline argument
+    ///
+    /// - d:<devicenode> path of bus and device-node (e.g. "003/001") within usb device tree (usually at /proc/bus/usb/)
+    /// - i:<vendor>:<product> first device with given vendor and product id, ids can be decimal, octal (preceded by "0") or hex (preceded by "0x")
+    /// - i:<vendor>:<product>:<index> as above with index being the number of the device (starting with 0) if there are more than one
+    /// - s:<vendor>:<product>:<serial> first device with given vendor id, product id and serial string
+    pub fn from_description_string(description: String) -> Result<Device> {
+        let context = Context::new()?;
+        let desc = CString::new(description).unwrap().into_raw();
+
+        let rc = unsafe { ftdic::ftdi_usb_open_string(context.get_ftdi_context(), desc) };
+
+        drop(unsafe { CString::from_raw(desc) }); // String must be manually free'd
+
+        context.check_ftdi_error(rc)?;
+        Ok(Device { context })
+    }
+
+    pub fn set_baudrate(&self, baudrate: u32) -> Result<()> {
+        let rc = unsafe { ftdic::ftdi_set_baudrate(self.context.0, baudrate as raw::c_int) };
 
         self.context.check_ftdi_error(rc)
     }
 
-    pub fn set_bitmode(&self, bitmask : u8, mode : MpsseMode) -> Result<()> {
+    pub fn set_bitmode(&self, bitmask: u8, mode: MpsseMode) -> Result<()> {
         let rc = unsafe {
-            ftdic::ftdi_set_bitmode(self.context.0, bitmask as raw::c_uchar, mode.0 as raw::c_uchar)
+            ftdic::ftdi_set_bitmode(
+                self.context.get_ftdi_context(),
+                bitmask as raw::c_uchar,
+                mode.0 as raw::c_uchar,
+            )
         };
 
         self.context.check_ftdi_error(rc)
     }
 
     pub fn purge_usb_buffers(&self) -> Result<()> {
-        let rc = unsafe {
-            ftdic::ftdi_usb_purge_buffers(self.context.0)
-        };
+        let rc = unsafe { ftdic::ftdi_usb_purge_buffers(self.context.get_ftdi_context()) };
 
         self.context.check_ftdi_error(rc)
     }
 
     pub fn purge_usb_rx_buffer(&self) -> Result<()> {
-        let rc = unsafe {
-            ftdic::ftdi_usb_purge_rx_buffer(self.context.0)
-        };
+        let rc = unsafe { ftdic::ftdi_usb_purge_rx_buffer(self.context.get_ftdi_context()) };
 
         self.context.check_ftdi_error(rc)
     }
 
     pub fn purge_usb_tx_buffer(&self) -> Result<()> {
-        let rc = unsafe {
-            ftdic::ftdi_usb_purge_tx_buffer(self.context.0)
-        };
+        let rc = unsafe { ftdic::ftdi_usb_purge_tx_buffer(self.context.get_ftdi_context()) };
 
         self.context.check_ftdi_error(rc)
     }
 
     pub fn read_pins(&self) -> Result<u8> {
-        let mut pins : u8 = 0;
+        let mut pins: u8 = 0;
         let pins_ptr = std::slice::from_mut(&mut pins).as_mut_ptr();
 
-        let rc = unsafe {
-            ftdic::ftdi_read_pins(self.context.0, pins_ptr)
-        };
+        let rc = unsafe { ftdic::ftdi_read_pins(self.context.get_ftdi_context(), pins_ptr) };
 
         self.context.check_ftdi_error(rc)?;
         Ok(pins)
     }
 
-    pub fn read_data(&self, data : &mut [u8]) -> Result<u32> {
+    pub fn read_data(&self, data: &mut [u8]) -> Result<u32> {
         let raw_ptr = data.as_mut_ptr();
         let raw_len = data.len() as i32;
 
-        let rc = unsafe {
-            ftdic::ftdi_read_data(self.context.0, raw_ptr, raw_len)
-        };
+        let rc =
+            unsafe { ftdic::ftdi_read_data(self.context.get_ftdi_context(), raw_ptr, raw_len) };
 
         self.context.check_ftdi_error(rc)?;
         Ok(rc as u32)
     }
 
-    pub fn write_data(&self, data : &[u8]) -> Result<u32> {
+    pub fn write_data(&self, data: &[u8]) -> Result<u32> {
         let raw_ptr = data.as_ptr();
         let raw_len = data.len() as i32;
 
-        let rc = unsafe {
-            ftdic::ftdi_write_data(self.context.0, raw_ptr, raw_len)
-        };
+        let rc =
+            unsafe { ftdic::ftdi_write_data(self.context.get_ftdi_context(), raw_ptr, raw_len) };
 
         self.context.check_ftdi_error(rc)?;
         Ok(rc as u32)
@@ -153,7 +217,8 @@ pub fn list_devices() -> Result<Vec<DeviceInfo>> {
     let context = Context::new()?;
     let mut device_list: *mut ftdic::ftdi_device_list = std::ptr::null_mut();
 
-    let rc = unsafe { ftdic::ftdi_usb_find_all(context.0, &mut device_list, 0, 0) };
+    let rc =
+        unsafe { ftdic::ftdi_usb_find_all(context.get_ftdi_context(), &mut device_list, 0, 0) };
     context.check_ftdi_error(rc)?;
 
     let mut devices = Vec::with_capacity(rc as usize);
@@ -163,9 +228,9 @@ pub fn list_devices() -> Result<Vec<DeviceInfo>> {
 
     let mut curdev = device_list;
     while !curdev.is_null() {
-        let rc =  unsafe {
+        let rc = unsafe {
             ftdic::ftdi_usb_get_strings(
-                context.0,
+                context.get_ftdi_context(),
                 (*curdev).dev,
                 manufacturer_buf.as_mut_ptr(),
                 manufacturer_buf.len() as i32,
@@ -180,9 +245,15 @@ pub fn list_devices() -> Result<Vec<DeviceInfo>> {
             return Err(e);
         }
 
-        let manufacturer = unsafe { CStr::from_ptr(manufacturer_buf.as_mut_ptr()) }.to_string_lossy().into_owned();
-        let description = unsafe { CStr::from_ptr(description_buf.as_mut_ptr()) }.to_string_lossy().into_owned();
-        let serial = unsafe { CStr::from_ptr(serial_buf.as_mut_ptr()) }.to_string_lossy().into_owned();
+        let manufacturer = unsafe { CStr::from_ptr(manufacturer_buf.as_mut_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+        let description = unsafe { CStr::from_ptr(description_buf.as_mut_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+        let serial = unsafe { CStr::from_ptr(serial_buf.as_mut_ptr()) }
+            .to_string_lossy()
+            .into_owned();
 
         devices.push(DeviceInfo {
             manufacturer,
@@ -201,5 +272,5 @@ pub fn list_devices() -> Result<Vec<DeviceInfo>> {
 pub struct DeviceInfo {
     manufacturer: String,
     description: String,
-    serial: String
+    serial: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,6 @@ use std::time::Duration;
 pub mod error;
 use error::{Error, LibFtdiError};
 
-extern crate bitflags;
-use bitflags::bitflags;
-
 /// Low-level wrapper around a ftdi_context instance
 pub struct Context(*mut ftdic::ftdi_context);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ impl Device {
             drop(unsafe { CString::from_raw(desc) }); // String must be manually free'd
         }
         if ser_supplied {
-            drop(unsafe { CString::from_raw(desc) }); // String must be manually free'd
+            drop(unsafe { CString::from_raw(ser) }); // String must be manually free'd
         }
         context.check_ftdi_error(rc)?;
         Ok(Device { context })
@@ -327,9 +327,9 @@ pub fn list_devices() -> Result<Vec<DeviceInfo>> {
     Ok(devices)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeviceInfo {
-    manufacturer: String,
-    description: String,
-    serial: String,
+    pub manufacturer: String,
+    pub description: String,
+    pub serial: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,11 +95,6 @@ pub enum BitMode {
     FT1284,
 }
 
-pub struct Device {
-    context: Context,
-    eeprom_read: bool,
-}
-
 pub struct AsyncRead<'b> {
     phantom: PhantomData<&'b mut [u8]>,
     transfer_control: *mut ftdic::ftdi_transfer_control,
@@ -127,6 +122,12 @@ impl<'b> AsyncRead<'b> {
 
         unsafe { ftdic::ftdi_transfer_data_cancel(self.transfer_control, &mut time) };
     }
+}
+
+/// High level control for a FTDI device
+pub struct Device {
+    context: Context,
+    eeprom_read: bool,
 }
 
 impl Device {

--- a/src/mpsse.rs
+++ b/src/mpsse.rs
@@ -1,2 +1,0 @@
-/* Reexports */
-pub use super::ftdic::ftdi_mpsse_mode as MpsseMode;


### PR DESCRIPTION
This is a pretty major update. I have changed the following things:
- Seperate ftdi_context from Device instance, as it is also needed for listing devices, etc
- Update libftdi1-sys to version `1.0.0`
- Added commands for:
     - ftdi_set_interface
     - ftdi_usb_open_desc
     - ftdi_usb_open_desc_index
     - ftdi_usb_open_bus_addr
     - ftdi_usb_open_string
     - ftdi_set_event_char
     - ftdi_set_error_char
     - ftdi_set_latency_timer
     - ftdi_setflowctrl
     - ftdi_setflowctrl_xonxoff
     - ftdi_read_data_set_chunksize
     - ftdi_write_data_set_chunksize
     - ftdi_read_data_submit
     - ftdi_transfer_data_done
     - ftdi_transfer_data_cancel
     - ftdi_read_eeprom/ftdi_eeprom_decode
     - ftdi_eeprom_get_strings
     - ftdi_usb_close
- Documented all functions
- Added enums for:
    - ftdi_interface
    - flow control constants
- Switched ftdi_mpsse_mode enum to proper rust enum
- Switched buffer flushing to use non-deprecated functions
- Bumped version to `0.3.0` due to breaking changes
- Updated mercpcl example
- Update readme to reflect changes
- Added feature to use vendored sources